### PR TITLE
DE-6746: Add a GH workflow to publish a release

### DIFF
--- a/.github/actions/apply-version/action.yml
+++ b/.github/actions/apply-version/action.yml
@@ -1,0 +1,11 @@
+name: 'Apply version'
+description: 'Apply version to package.json, readme and docs, also update versioned links'
+
+inputs:
+  version:
+    description: The SDK version
+    required: true
+
+runs:
+  using: 'node16'
+  main: './main.js'

--- a/.github/actions/apply-version/action.yml
+++ b/.github/actions/apply-version/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: './main.js'

--- a/.github/actions/apply-version/main.js
+++ b/.github/actions/apply-version/main.js
@@ -1,20 +1,12 @@
 const fs = require('fs')
-const path = require('path')
 const execSync = require('child_process').execSync
 const core = require('@actions/core')
+const utils = require('../utils')
 
 /**
  * @fileoverview Replace version and links to API docs with the current/fresh
  * value where needed (package.json, readme, storybook intro).
  */
-
-/**
- * @param {string} filepath relative to project root
- * @return {string} absolute path
- */
-function file(filepath) {
-  return path.resolve(__dirname, `../../../${filepath}`)
-}
 
 const TOKENS = {
   LINK_DOCS: 'CI_REPLACE_LINK_DOCS',
@@ -22,8 +14,8 @@ const TOKENS = {
 }
 
 const FILES = {
-  README: file('README.md'),
-  STORYBOOK_INTRO: file('story/stories/Intro.mdx'),
+  README: utils.file('README.md'),
+  STORYBOOK_INTRO: utils.file('story/stories/Intro.mdx'),
 }
 
 const version = core.getInput('version', {required: true})

--- a/.github/actions/apply-version/main.js
+++ b/.github/actions/apply-version/main.js
@@ -1,0 +1,81 @@
+const fs = require('fs')
+const path = require('path')
+const execSync = require('child_process').execSync
+const core = require('@actions/core')
+
+/**
+ * @fileoverview Replace version and links to API docs with the current/fresh
+ * value where needed (package.json, readme, storybook intro).
+ */
+
+/**
+ * @param {string} filepath relative to project root
+ * @return {string} absolute path
+ */
+function file(filepath) {
+  return path.resolve(__dirname, `../../../${filepath}`)
+}
+
+const TOKENS = {
+  LINK_DOCS: 'CI_REPLACE_LINK_DOCS',
+  VERSION: 'CI_REPLACE_VERSION',
+}
+
+const FILES = {
+  README: file('README.md'),
+  STORYBOOK_INTRO: file('story/stories/Intro.mdx'),
+}
+
+const version = core.getInput('version', {required: true})
+
+// Note: The trailing slash is very important here, it won't work without it.
+const homepage = `https://players.castlabs.com/react-dom/${version}/docs/`
+
+core.info(`API docs link is: ${homepage}`)
+
+/**
+ * Set the "version" attribute in package.json
+ * @param {string} version
+ */
+function updatePackageJson(version) {
+  core.info(`Set package.json version to ${version}`)
+  execSync(`npm pkg set version=${version};`, { stdio: 'inherit' })
+}
+
+/**
+ * Replace token by link in the README.md file
+ * @param {string} link
+ */
+function addLinkToReadme(link) {
+  core.info(`Adding link to ${FILES.README}`)
+  replaceText(FILES.README, TOKENS.LINK_DOCS, link)
+}
+
+/**
+ * Replace token by version in Storybook Intro.mdx file
+ * @param {string} version
+ */
+function addVersionToStorybook(version) {
+  core.info(`Adding version to ${FILES.STORYBOOK_INTRO}`)
+  replaceText(FILES.STORYBOOK_INTRO, TOKENS.VERSION, version)
+}
+
+/**
+ * @param {string} filename file
+ * @param {string} token token to replace
+ * @param {string} text replacement text
+ */
+function replaceText(filename, token, text) {
+  const content = fs.readFileSync(filename, 'utf8')
+  fs.writeFileSync(filename, content.replace(token, text))
+}
+
+try {
+  addLinkToReadme(homepage)
+  addVersionToStorybook(version)
+  updatePackageJson(version)
+  core.info('Success')
+} catch (err) {
+  core.error('Failed to generated links to API docs' + err)
+  process.exit(1)
+}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: './main.js'

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: The SDK version
     required: true
-  dryRun:
+  dry-run:
     description: If true, run the commands but don't publish to NPM
     required: false
 

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -5,6 +5,9 @@ inputs:
   version:
     description: The SDK version
     required: true
+  npm-token:
+    description: The NPM token
+    required: true
   dry-run:
     description: If true, run the commands but don't publish to NPM
     required: false

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,0 +1,14 @@
+name: 'Publish'
+description: 'Publish to NPM, if it is a beta version publish to beta channel'
+
+inputs:
+  version:
+    description: The SDK version
+    required: true
+  dryRun:
+    description: If true, run the commands but don't publish to NPM
+    required: false
+
+runs:
+  using: 'node16'
+  main: './main.js'

--- a/.github/actions/publish/main.js
+++ b/.github/actions/publish/main.js
@@ -46,7 +46,7 @@ if (versionInfo === null) {
 }
 
 const { type, label } = versionInfo;
-const args = []
+const args = ['--provenance']
 if (dryRun) {
   args.push('--dry-run')
 }

--- a/.github/actions/publish/main.js
+++ b/.github/actions/publish/main.js
@@ -6,28 +6,52 @@ const core = require('@actions/core')
  * (e.g. 1.2.3-beta.4 or 1.2.3-alpha.1 etc.) then publish to a beta channel.
  */
 
+/**
+ * @typedef {'normal'|'beta'} VersionType
+ * @typedef {{ type: VersionType, label?: string }} VersionInfo
+ */
+
+/**
+ * @param {string} version version string
+ * @return {VersionInfo|null} version info or null if invalid
+ */
+function parseVersion(version) {
+  const regexBetaVersion = /^\d+\.\d+\.\d+-(\w+)\.\d+$/;
+  const regexVersion = /^\d+\.\d+\.\d+$/;
+
+  const betaMatch = version.match(regexBetaVersion);
+  if (betaMatch) {
+    const label = betaMatch[1];
+    return { type: 'beta', label };
+  }
+
+  const isNormal = regexVersion.test(version);
+  if (isNormal) {
+    return { type: 'normal' };
+  }
+
+  return null;
+}
+
+
 const version = core.getInput('version', {required: true})
-const dryRun = core.getBooleanInput('dryRun')
+const dryRun = core.getBooleanInput('dry-run')
 
-const regexBetaVersion = /^\d+\.\d+\.\d+-(\w+)\.\d+$/;
-const regexVersion = /^\d+\.\d+\.\d+$/;
+const versionInfo = parseVersion(version)
 
-const betaMatch = version.match(regexBetaVersion);
-
-if (betaMatch) {
-  const betaLabel = betaMatch[1];
-  core.info(`Publishing a Beta version ${version}.`)
-  execSync(`npm publish ${dryRun ? '--dry-run' : ''} --tag ${betaLabel}`, { stdio: 'inherit' })
-  process.exit(0);
+if (versionInfo === null) {
+  core.error(`Invalid version format. Version: ${version}`)
+  process.exit(1)
 }
 
-const isNormal = regexVersion.test(version);
-
-if (isNormal) {
-  core.info(`Publishing version ${version}.`)
-  execSync(`npm publish ${dryRun ? '--dry-run' : ''}`, { stdio: 'inherit' })
-  process.exit(0);
+const { type, label } = versionInfo;
+const args = []
+if (dryRun) {
+  args.push('--dry-run')
+}
+if (label) {
+  args.push(`--tag ${label}`)
 }
 
-core.error(`Invalid version format. Version: ${version}`);
-process.exit(1);
+core.info(`Publishing ${type === 'beta' ? 'Beta version' : 'version'} ${version}.`)
+execSync(`npm publish ${args.join(' ')}`, { stdio: 'inherit' })

--- a/.github/actions/publish/main.js
+++ b/.github/actions/publish/main.js
@@ -1,0 +1,33 @@
+const execSync = require('child_process').execSync
+const core = require('@actions/core')
+
+/**
+ * @fileoverview Publish to NPM, if the version is in the beta format
+ * (e.g. 1.2.3-beta.4 or 1.2.3-alpha.1 etc.) then publish to a beta channel.
+ */
+
+const version = core.getInput('version', {required: true})
+const dryRun = core.getBooleanInput('dryRun')
+
+const regexBetaVersion = /^\d+\.\d+\.\d+-(\w+)\.\d+$/;
+const regexVersion = /^\d+\.\d+\.\d+$/;
+
+const betaMatch = version.match(regexBetaVersion);
+
+if (betaMatch) {
+  const betaLabel = betaMatch[1];
+  core.info(`Publishing a Beta version ${version}.`)
+  execSync(`npm publish ${dryRun ? '--dry-run' : ''} --tag ${betaLabel}`, { stdio: 'inherit' })
+  process.exit(0);
+}
+
+const isNormal = regexVersion.test(version);
+
+if (isNormal) {
+  core.info(`Publishing version ${version}.`)
+  execSync(`npm publish ${dryRun ? '--dry-run' : ''}`, { stdio: 'inherit' })
+  process.exit(0);
+}
+
+core.error(`Invalid version format. Version: ${version}`);
+process.exit(1);

--- a/.github/actions/publish/main.js
+++ b/.github/actions/publish/main.js
@@ -35,6 +35,7 @@ function parseVersion(version) {
 
 
 const version = core.getInput('version', {required: true})
+const npmToken = core.getInput('npm-token', {required: true})
 const dryRun = core.getBooleanInput('dry-run')
 
 const versionInfo = parseVersion(version)
@@ -54,4 +55,4 @@ if (label) {
 }
 
 core.info(`Publishing ${type === 'beta' ? 'Beta version' : 'version'} ${version}.`)
-execSync(`npm publish ${args.join(' ')}`, { stdio: 'inherit' })
+execSync(`export NPM_TOKEN=${npmToken}; npm publish ${args.join(' ')}`, { stdio: 'inherit' })

--- a/.github/actions/publish/main.js
+++ b/.github/actions/publish/main.js
@@ -1,5 +1,7 @@
 const execSync = require('child_process').execSync
 const core = require('@actions/core')
+const fs = require('fs')
+const utils = require('../utils')
 
 /**
  * @fileoverview Publish to NPM, if the version is in the beta format
@@ -55,4 +57,16 @@ if (label) {
 }
 
 core.info(`Publishing ${type === 'beta' ? 'Beta version' : 'version'} ${version}.`)
-execSync(`export NPM_TOKEN=${npmToken}; npm publish ${args.join(' ')}`, { stdio: 'inherit' })
+
+const npmRcContent = `
+@castlabs:registry=https://registry.npmjs.org
+//registry.npmjs.org/:_authToken=\${NPM_TOKEN}
+`
+
+try {
+  fs.writeFileSync(utils.file('.npmrc'), npmRcContent)
+  execSync(`export NPM_TOKEN=${npmToken}; npm publish ${args.join(' ')}`, { stdio: 'inherit' })
+} catch (error) {
+  core.error('Failed to publish to NPM' + error)
+  process.exit(1)
+}

--- a/.github/actions/publish/main.js
+++ b/.github/actions/publish/main.js
@@ -65,7 +65,10 @@ const npmRcContent = `
 
 try {
   fs.writeFileSync(utils.file('.npmrc'), npmRcContent)
-  execSync(`export NPM_TOKEN=${npmToken}; npm publish ${args.join(' ')}`, { stdio: 'inherit' })
+  execSync(
+    `npm publish ${args.join(' ')}`,
+    { stdio: 'inherit',  env: { ...process.env, NPM_TOKEN: npmToken }},
+  )
 } catch (error) {
   core.error('Failed to publish to NPM' + error)
   process.exit(1)

--- a/.github/actions/upload-to-s3/action.yml
+++ b/.github/actions/upload-to-s3/action.yml
@@ -1,0 +1,17 @@
+name: 'Upload to S3'
+description: 'Upload the contents of a directory to an S3 bucket'
+
+inputs:
+  directory:
+    description: Directory to upload
+    required: true
+  destination:
+    description: S3 destination path URI
+    required: true
+  dry-run:
+    description: If true, run the commands but don't actually upload
+    required: false
+
+runs:
+  using: 'node20'
+  main: './main.js'

--- a/.github/actions/upload-to-s3/main.js
+++ b/.github/actions/upload-to-s3/main.js
@@ -1,0 +1,21 @@
+const execSync = require('child_process').execSync
+const core = require('@actions/core')
+
+/**
+ * @fileoverview Upload a directory to S3.
+ */
+
+const directory = core.getInput('directory', {required: true})
+const destination = core.getInput('destination', {required: true})
+const dryRun = core.getBooleanInput('dry-run')
+
+const args = ['--recursive']
+if (dryRun) {
+  args.push('--dryrun')
+}
+
+core.info(`Uploading ${directory} to S3.`)
+execSync(`aws s3 cp ${args.join(' ')} "${directory}" "${destination}"`, { stdio: 'inherit' })
+// Note: the default cache policy is 1 day, I think that's OK for now.
+// In the future if traffic increases we can increase the expiration
+// as much as we want.

--- a/.github/actions/utils.js
+++ b/.github/actions/utils.js
@@ -1,0 +1,13 @@
+const path = require('path')
+
+/**
+ * @param {string} filepath relative to project root
+ * @return {string} absolute path
+ */
+function file(filepath) {
+  return path.resolve(__dirname, `../../${filepath}`)
+}
+
+module.exports = {
+  file,
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Build
 
 on:
   push:
@@ -7,21 +7,22 @@ on:
   pull_request:
     branches:
       - main
-      
+
 jobs:
   build:
     name: Build
     runs-on: [ubuntu-latest]
-    
-    steps:
-      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        name: Setup Node
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm
-          
+
       - name: NPM Install
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/publish
         with:
           version: ${{ env.VERSION }}
-          dryRun: false
+          dry-run: false
 
       - name: Add Job summary
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/publish
         with:
           version: ${{ env.VERSION }}
-          npm-token: ${{ secrets.CLPLAYERS_NPM_TOKEN_RW }}
+          npm-token: ${{ secrets.CLPLAYERS_NPM_TOKEN_REACT_COMPONENTS }}
           dry-run: ${{ env.DRY_RUN }}
 
       - name: Add Job summary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     types: [released]
 
 env:
-  NPM_TOKEN: ${{ secrets.CLPLAYERS_NPM_TOKEN_RW }}
   VERSION: ${{ github.event.release.tag_name }}
   WEB_PATH: "react-dom/${{ github.event.release.tag_name }}/docs/"
 
@@ -54,11 +53,6 @@ jobs:
 
     ## Publish the NPM package
 
-      - name: Write NPM RC File
-        run: |
-          echo '@castlabs:registry=https://registry.npmjs.org' > .npmrc
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
-
       - name: Build
         run: npm run build
 
@@ -66,6 +60,7 @@ jobs:
         uses: ./.github/actions/publish
         with:
           version: ${{ env.VERSION }}
+          npm-token: ${{ secrets.CLPLAYERS_NPM_TOKEN_RW }}
           dry-run: false
 
       - name: Add Job summary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish
+
+on:
+  release:
+    types: [released]
+
+env:
+  NPM_TOKEN: ${{ secrets.CLPLAYERS_NPM_TOKEN_RW }}
+  VERSION: ${{ github.event.release.tag_name }}
+  WEB_PATH: "react-dom/${{ github.event.release.tag_name }}/docs/"
+
+permissions:
+  contents: read # Permission for actions/checkout
+  id-token: write # Permission for aws-actions/configure-aws-credentials
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Apply version to package.json, readme and docs
+        uses: ./.github/actions/apply-version
+        with:
+          version: ${{ env.VERSION }}
+
+    ## Publish the API docs
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_UPLOADER_ROLE_PLAYERS }}
+          aws-region: us-east-1
+
+      - name: Upload to S3
+        run: aws s3 cp --recursive "./dist/storybook" "${{ secrets.AWS_WEB_BUCKET }}/${{ env.WEB_PATH }}"
+        # Note: the default cache policy is 1 day, I think that's OK for now.
+        # In the future if traffic increases we can increase the expiration
+        # as much as we want.
+
+    ## Publish the NPM package
+
+      - name: Write NPM RC File
+        run: |
+          echo '@castlabs:registry=https://registry.npmjs.org' > .npmrc
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to NPM
+        uses: ./.github/actions/publish
+        with:
+          version: ${{ env.VERSION }}
+          dryRun: false
+
+      - name: Add Job summary
+        run: |
+          echo '### NPM Release' >> $GITHUB_STEP_SUMMARY
+          echo "Released version ${{ env.VERSION }} of https://www.npmjs.com/package/@castlabs/prestoplay-react-components" >> $GITHUB_STEP_SUMMARY
+          echo '### Docs' >> $GITHUB_STEP_SUMMARY
+          echo "Published docs to https://players.castlabs.com/${{ env.WEB_PATH }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 env:
   VERSION: ${{ github.event.release.tag_name }}
   WEB_PATH: "react-dom/${{ github.event.release.tag_name }}/docs/"
+  DRY_RUN: false
 
 permissions:
   contents: read # Permission for actions/checkout
@@ -46,10 +47,11 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload to S3
-        run: aws s3 cp --recursive "./dist/storybook" "${{ secrets.AWS_WEB_BUCKET }}/${{ env.WEB_PATH }}"
-        # Note: the default cache policy is 1 day, I think that's OK for now.
-        # In the future if traffic increases we can increase the expiration
-        # as much as we want.
+        uses: ./.github/actions/upload-to-s3
+        with:
+          directory: "./dist/storybook"
+          destination: "${{ secrets.AWS_WEB_BUCKET }}/${{ env.WEB_PATH }}"
+          dry-run: ${{ env.DRY_RUN }}
 
     ## Publish the NPM package
 
@@ -61,7 +63,7 @@ jobs:
         with:
           version: ${{ env.VERSION }}
           npm-token: ${{ secrets.CLPLAYERS_NPM_TOKEN_RW }}
-          dry-run: false
+          dry-run: ${{ env.DRY_RUN }}
 
       - name: Add Job summary
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
     ## Publish the API docs
 
-      - name: Build Storybook
+      - name: Build API Docs
         run: npm run build-storybook
 
       - name: Assume AWS role
@@ -46,7 +46,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_UPLOADER_ROLE_PLAYERS }}
           aws-region: us-east-1
 
-      - name: Upload to S3
+      - name: Upload API Docs
         uses: ./.github/actions/upload-to-s3
         with:
           directory: "./dist/storybook"

--- a/README.md
+++ b/README.md
@@ -1,138 +1,30 @@
 # PRESTOplay React Components (Beta)
 
-This is a React Component library that provides components to build user interfaces for PRESTOplay video player.
+This library provides a React UI for [@castlabs/prestoplay](https://www.npmjs.com/package/@castlabs/prestoplay). Individual components can be imported separately in order to
+build a custom UI.
 
-⚠️ *Currently this is in Beta version (0.x.x), therefore be aware that breaking changes may occur between minor releases. The versions will switch to standard semantic versioning once version 1.0.0 is released.* ⚠️
+
+> ⚠️ Warning: *This is in Beta version (0.x.x), therefore be aware that breaking changes may occur between minor releases. The versions will switch to standard semantic versioning once version 1.0.0 is released.*
 
 ## Installation
-
-The library can be installed as a dependency from NPM:
 
 ```sh
 npm i @castlabs/prestoplay-react-components
 ```
 
-Please note that you should also install the peer dependencies, i.e. `react`, `react-dom` and 
-`@castlabs/prestoplay`:
+Install peer dependencies
 
 ```sh
-npm i react@18 react-dom@18 @castlabs/prestoplay@6.2
+npm i react@18 react-dom@18 @castlabs/prestoplay
 ```
 
-## Getting started
+_This library is compatible with React version 18 and @castlabs/prestoplay
+version 6.2.0 and higher._
 
-### Render a basic video element
+## API
 
-Use the `PlayerSurface` component to render a basic player surface that will load and play the provided video without
-any UI controls.
-
-```jsx
-import React, { useState } from 'react'
-// Load the prestoplay modules that are needed for the project
-import { clpp } from "@castlabs/prestoplay"
-import "@castlabs/prestoplay/cl.mse"
-import "@castlabs/prestoplay/cl.dash"
-import "@castlabs/prestoplay/cl.thumbnails"
-import "@castlabs/prestoplay/cl.htmlcue"
-import "@castlabs/prestoplay/cl.ttml"
-import "@castlabs/prestoplay/cl.vtt"
-import { Player, PlayerSurface } from "@castlabs/prestoplay-react-components/"
-
-// Load CSS for PRESTOplay
-import "@castlabs/prestoplay/clpp.styles.css"
-// Load CSS for PRESTOplay React
-import "@castlabs/prestoplay-react-components/dist/themes/pp-ui-base-theme-embedded.css"
-
-const baseConfig = {
-  license: "...",
-}
-
-const App = () => {
-  const [player] = useState(new Player((pp) => {
-    // pp is an instance of clpp.Player from @castlabs/prestoplay
-    pp.use(clpp.dash.DashComponent);
-    pp.use(clpp.htmlcue.HtmlCueComponent)
-    pp.use(clpp.ttml.TtmlComponent)
-    pp.use(clpp.vtt.VttComponent)
-  }))
-
-  const [loadConfig, setLoadConfig] = useState<any>({
-    source: "https://content.players.castlabs.com/demos/clear-segmented/manifest.mpd",
-    autoplay: true,
-    muted: true
-  })
-
-  return (
-    <PlayerSurface
-      player={player}
-      baseConfig={baseConfig}
-      config={loadConfig}
-      autoload/>
-  )
-}
-```
-
-### Render video with UI controls
-
-Use the `BaseThemeOverlay` component to get started with a set of basic UI controls. It serves as a small, 
-basic implementation of a UI theme.
-
-```jsx
-import React, { useState } from 'react'
-// Load the prestoplay modules that are needed for the project
-import { clpp } from "@castlabs/prestoplay"
-import "@castlabs/prestoplay/cl.mse"
-import "@castlabs/prestoplay/cl.dash"
-import "@castlabs/prestoplay/cl.thumbnails"
-import "@castlabs/prestoplay/cl.htmlcue"
-import "@castlabs/prestoplay/cl.ttml"
-import "@castlabs/prestoplay/cl.vtt"
-import { Player, PlayerSurface, BaseThemeOverlay } from "@castlabs/prestoplay-react-components/"
-
-// Load CSS for PRESTOplay
-import "@castlabs/prestoplay/clpp.styles.css"
-// Load CSS for PRESTOplay React
-import "@castlabs/prestoplay-react-components/dist/themes/pp-ui-base-theme-embedded.css"
-
-const baseConfig = {
-  license: "...",
-}
-
-const App = () => {
-  const [player] = useState(new Player((pp) => {
-    // pp is an instance of clpp.Player from @castlabs/prestoplay
-    pp.use(clpp.dash.DashComponent);
-    pp.use(clpp.htmlcue.HtmlCueComponent)
-    pp.use(clpp.ttml.TtmlComponent)
-    pp.use(clpp.vtt.VttComponent)
-  }))
-
-  const [loadConfig, setLoadConfig] = useState<any>({
-    source: "https://content.players.castlabs.com/demos/clear-segmented/manifest.mpd",
-    autoplay: true,
-    muted: true
-  })
-
-  return (
-    <PlayerSurface
-      player={player}
-      baseConfig={baseConfig}
-      config={loadConfig}
-      autoload>
-        <BaseThemeOverlay/>
-    </PlayerSurface>
-  )
-}
-```
-
-## Building a custom UI
-
-⚠️ ***Coming soon**: This section is under construction. More examples and documentation is coming soon.* ⚠️
-
-Use individual UI components from `@castlabs/prestoplay-react-components` to build a customized UI.
-
-- [UI Components](https://github.com/castlabs/prestoplay-react-components/tree/main/src/components)
-- [Examples of customized UI](https://github.com/castlabs/prestoplay-react-components/tree/main/app/src)
+See the [API docs](CI_REPLACE_LINK_DOCS).
 
 ## Changelog
-- [Changelog](https://github.com/castlabs/prestoplay-react-components/blob/main/CHANGELOG.md)
+
+See the [Changelog](https://github.com/castlabs/prestoplay-react-components/blob/main/CHANGELOG.md).

--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -24,10 +24,18 @@ npm run build
 
 ## Publish
 
-To publish the library:
-```sh
-npm run publish
-```
+Create a release in GitHub and select a tag to create along with the release
+(e.g. `1.0.0`), the tag must be equal to the version to be released. This will
+trigger a GitHub action which will publish the release.
+
+### Publish a Beta version
+
+To publish a beta version the process is the same, just use a "beta" format for
+the version string (e.g. `1.0.0-<beta>.1`), where `<beta>` can be any
+alphabetical string (letters only).
+
+The `publish` workflow will automatically publish this package into
+a `<beta>` (non-main) NPM channel.
 
 ## Test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@castlabs/prestoplay-react-components",
-  "version": "0.6.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@castlabs/prestoplay-react-components",
-      "version": "0.6.0",
+      "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@react-hook/resize-observer": "^1.2.6"
       },
       "devDependencies": {
+        "@actions/core": "^1.10.1",
         "@babel/preset-env": "^7.22.4",
         "@babel/preset-react": "^7.22.3",
         "@babel/preset-typescript": "^7.21.5",
@@ -77,6 +78,35 @@
         "@castlabs/prestoplay": "^6.6.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "dev": true,
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
+      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "dev": true,
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2479,6 +2509,15 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@finga/eslint-config": {
       "version": "1.2.1",
@@ -17616,6 +17655,15 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "dev": true,
@@ -17712,6 +17760,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.1.tgz",
+      "integrity": "sha512-xcIIvj1LOQH9zAL54iWFkuDEaIVEjLrru7qRpa3GrEEHk6OBhb/LycuUY2m7VCcTuDeLziXCxobQVyKExyGeIA==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/unfetch": {
@@ -18430,6 +18490,34 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
+      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "dev": true,
+      "requires": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
     "@adobe/css-tools": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
@@ -19867,6 +19955,12 @@
     },
     "@fal-works/esbuild-plugin-global-externals": {
       "version": "2.1.2",
+      "dev": true
+    },
+    "@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
       "dev": true
     },
     "@finga/eslint-config": {
@@ -29747,6 +29841,12 @@
         }
       }
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "dev": true,
@@ -29800,6 +29900,15 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.1.tgz",
+      "integrity": "sha512-xcIIvj1LOQH9zAL54iWFkuDEaIVEjLrru7qRpa3GrEEHk6OBhb/LycuUY2m7VCcTuDeLziXCxobQVyKExyGeIA==",
+      "dev": true,
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "unfetch": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/castlabs/prestoplay-react-components",
   "repository": {
     "type": "git",
-    "url": "https://github.com/castlabs/prestoplay-react-components"
+    "url": "git+https://github.com/castlabs/prestoplay-react-components.git"
   },
   "bugs": {
     "url": "https://github.com/castlabs/prestoplay-react-components/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@castlabs/prestoplay-react-components",
-  "version": "0.6.0",
+  "version": "0.0.0",
   "description": "React components for PRESTOplay",
   "homepage": "https://github.com/castlabs/prestoplay-react-components",
   "repository": {
@@ -10,13 +10,12 @@
   "bugs": {
     "url": "https://github.com/castlabs/prestoplay-react-components/issues"
   },
-  "author": "castLabs GmbH",
+  "author": "castLabs GmbH (https://castlabs.com/)",
   "browser": "dist/prestoplay-react.cjs.min.js",
   "main": "dist/prestoplay-react.cjs.min.js",
   "module": "dist/index.js",
   "types": "dist/prestoplay-react.d.ts",
   "scripts": {
-    "prepublishOnly": "bash ./scripts/prepublish.sh",
     "build": "bash ./scripts/build.sh",
     "start": "bash ./scripts/start.sh",
     "test": "jest",
@@ -27,6 +26,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@actions/core": "^1.10.1",
     "@babel/preset-env": "^7.22.4",
     "@babel/preset-react": "^7.22.3",
     "@babel/preset-typescript": "^7.21.5",

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e;
-
-npm run test;
-npm run build;
-npx es-check es5 ./dist/prestoplay-react.cjs.min.js;

--- a/story/stories/Intro.mdx
+++ b/story/stories/Intro.mdx
@@ -10,7 +10,7 @@ import cover from './cover.png'
 </div>
 
 
-# PRESTOplay React v0.6.0 (#Beta)
+# PRESTOplay React vCI_REPLACE_VERSION (Beta)
 
 This library provides React components to build user interfaces for PRESTOplay video player. It comes with
 a configurable ready-to-use UI as well as a set of individual components and hooks that can
@@ -18,31 +18,26 @@ be assembled in order to build a custom UI.
 
 ## Installation
 
-The library can be installed as a dependency from
-<Link uri="https://www.npmjs.com/package/@castlabs/prestoplay-react-components">NPM</Link>:
+Install 
+<Link uri="https://www.npmjs.com/package/@castlabs/prestoplay-react-components">PRESTOplay React</Link> and its peer dependencies:
 
 ```sh
-npm i @castlabs/prestoplay-react-components
-```
-
-Please note that you should also install the peer dependencies, i.e. `react`, `react-dom` and `@castlabs/prestoplay`:
-
-```sh
-npm i react@18 react-dom@18 @castlabs/prestoplay@6.2
+npm i @castlabs/prestoplay-react-components react@18 react-dom@18 @castlabs/prestoplay
 ```
 
 *This library is compatible with React version 18 and `@castlabs/prestoplay` version 6.2.0 and higher.*
 
 
-## Using Default UI
+## Default UI Skin
 
-PRESTOplay React comes with a ready-to-use skin, <Link title="Examples Default Skin">TRY IT OUT</Link>!
-
-(About skinning and CSS classes).
+PRESTOplay React comes with a ready-to-use UI skin, <Link title="Examples Default Skin">try it out!</Link>
 
 ## Building Custom UIs
 
-<Link title="Examples Youtube Skin">Youtube-like example</Link>
+Individual components can be imported separately and assembled to build
+a custom UI skin. Check out
+<Link title="Examples Youtube Skin">this tutorial</Link> on how to build
+a custom UI styled to resemble the Youtube player.
 
 
 

--- a/story/stories/examples/DefaultSkinSource.tsx
+++ b/story/stories/examples/DefaultSkinSource.tsx
@@ -14,8 +14,9 @@ import '@castlabs/prestoplay/clpp.styles.css'
 import '@castlabs/prestoplay-react-components/dist/themes/pp-ui-base-theme-embedded.css'
 
 const baseConfig = {
-  // Replace this by your license key
-  license: '7c816...81d53b1c',
+  // For production uncomment this and insert your license key
+  // (for local development a license is not required)
+  // license: '',
 }
 
 const player = new Player(pp => {

--- a/story/stories/examples/DefaultSkinSource.tsx
+++ b/story/stories/examples/DefaultSkinSource.tsx
@@ -6,6 +6,7 @@ import '@castlabs/prestoplay/cl.hls'
 import '@castlabs/prestoplay/cl.htmlcue'
 import '@castlabs/prestoplay/cl.ttml'
 import '@castlabs/prestoplay/cl.vtt'
+
 import { Player, BaseThemeOverlay, PlayerSurface } from '@castlabs/prestoplay-react-components'
 import React from 'react'
 
@@ -14,7 +15,7 @@ import '@castlabs/prestoplay-react-components/dist/themes/pp-ui-base-theme-embed
 
 const baseConfig = {
   // Replace this by your license key
-  license: '7c8165eb7231508ce4eae02181d53b1c',
+  license: '7c816...81d53b1c',
 }
 
 const player = new Player(pp => {
@@ -26,7 +27,7 @@ const player = new Player(pp => {
 })
 
 const sourceConfig = {
-  source: 'https://content.players.castlabs.com/demos/clear-segmented/manifest.mpd',
+  source: 'https://c.../manifest.mpd',
 }
 
 const App = () => {

--- a/story/stories/examples/YoutubeSkinSource.ts
+++ b/story/stories/examples/YoutubeSkinSource.ts
@@ -26,8 +26,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 
 const baseConfig = {
-  // Replace this by your license key
-  license: '7c8165...81d53b1c',
+  // For production uncomment this and insert your license key
+  // (for local development a license is not required)
+  license: '',
 }
 
 const sourceConfig = {

--- a/story/stories/examples/YoutubeSkinSource.ts
+++ b/story/stories/examples/YoutubeSkinSource.ts
@@ -1,3 +1,5 @@
+// TODO fix the import paths here!
+
 export const SOURCE_YOUTUBE_SKIN = `
 import { clpp } from '@castlabs/prestoplay'
 import '@castlabs/prestoplay/cl.mse'
@@ -7,23 +9,13 @@ import '@castlabs/prestoplay/cl.htmlcue'
 import '@castlabs/prestoplay/cl.ttml'
 import '@castlabs/prestoplay/cl.vtt'
 
-import { Player } from '@castlabs/prestoplay-react-components'
-import { CurrentTime } from '@castlabs/prestoplay-react-components/components/CurrentTime'
-import { Duration } from '@castlabs/prestoplay-react-components/components/Duration'
-import { FullscreenButton } from '@castlabs/prestoplay-react-components/components/FullscreenButton'
-import { HorizontalBar } from '@castlabs/prestoplay-react-components/components/HorizontalBar'
-import { HoverContainer } from '@castlabs/prestoplay-react-components/components/HoverContainer'
-import { Label } from '@castlabs/prestoplay-react-components/components/Label'
-import { MuteButton } from '@castlabs/prestoplay-react-components/components/MuteButton'
-import { PlayerControls } from '@castlabs/prestoplay-react-components/components/PlayerControls'
-import { PlayerSurface } from '@castlabs/prestoplay-react-components/components/PlayerSurface'
-import { PlayPauseButton } from '@castlabs/prestoplay-react-components/components/PlayPauseButton'
-import { PlayPauseIndicator } from '@castlabs/prestoplay-react-components/components/PlayPauseIndicator'
-import { SeekBar } from '@castlabs/prestoplay-react-components/components/SeekBar'
-import { Spacer } from '@castlabs/prestoplay-react-components/components/Spacer'
-import { Thumbnail } from '@castlabs/prestoplay-react-components/components/Thumbnail'
-import { VerticalBar } from '@castlabs/prestoplay-react-components/components/VerticalBar'
-import { VolumeBar } from '@castlabs/prestoplay-react-components/components/VolumeBar'
+import {
+  Player, CurrentTime, Duration, FullscreenButton, HorizontalBar,
+  HoverContainer, Label, MuteButton, PlayerControls, PlayerSurface,
+  PlayPauseButton, PlayPauseIndicator, SeekBar, Spacer, Thumbnail,
+  VerticalBar, VolumeBar,
+} from '@castlabs/prestoplay-react-components'
+
 import React from 'react'
 
 import '@castlabs/prestoplay/clpp.styles.css'
@@ -32,16 +24,14 @@ import 'youtube-style.css'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
-const asset =   {
-  title: 'Maldives',
-  subtitle: 'State of the Mahal Dibiyat',
-  config: {
-    source: 'https://content.players.castlabs.com/demos/clear-segmented/manifest.mpd',
-  },
+
+const baseConfig = {
+  // Replace this by your license key
+  license: '7c8165...81d53b1c',
 }
 
-const playerConfig = {
-  source: asset.config.source ?? '',
+const sourceConfig = {
+  source: 'https://.../manifest.mpd',
 }
 
 const player = new Player((pp: clpp.Player) => {
@@ -60,7 +50,8 @@ const YoutubeSkin = () => {
   return (
     <PlayerSurface
       player={player}
-      config={playerConfig}
+      baseConfig={baseConfig}
+      config={sourceConfig}
       playsInline={true}
       autoload={true}
       style={{ height: '320px' }}>
@@ -73,8 +64,7 @@ const YoutubeSkin = () => {
           <div className='pp-ui-layer'>
             <div className="pp-ui-top-and-bottom-layout">
 
-              {/* Top half: */}
-              {/* The first horizontal row shows some custom title for the content */}
+              {/* Top - a custom title for the content */}
               <HorizontalBar>
                 <div style={{ flexGrow: 1 }}>
                   <div>
@@ -86,10 +76,11 @@ const YoutubeSkin = () => {
                 </div>
               </HorizontalBar>
 
-              {/* Bottom half: */}
+              {/* Bottom half */}
               <div>
                 <div className="pp-yt-gradient-bottom"></div>
-                {/* We create a horizontal bar for the thumbnails */}
+
+                {/* A container for thumbnails that appear when hover over the seek bar */}
                 <HorizontalBar>
                   <HoverContainer>
                     <Thumbnail moveRelativeToParent={false}/>
@@ -97,7 +88,7 @@ const YoutubeSkin = () => {
                   </HoverContainer>
                 </HorizontalBar>
 
-
+                {/* Seek bar, play buttons etc. */}
                 <VerticalBar>
                   <HorizontalBar style={{ alignItems: 'flex-end', marginBottom: '-8px' }}>
                     <SeekBar  adjustWhileDragging={true} enableThumbnailSlider={false} notFocusable={true}/>
@@ -119,11 +110,11 @@ const YoutubeSkin = () => {
                     <FullscreenButton />
                   </HorizontalBar>
                 </VerticalBar>
+
               </div>
             </div>
           </div>
         </div>
-   
       </PlayerControls>
     </PlayerSurface>
   )


### PR DESCRIPTION
Here I'm adding a GitHub workflow to publish a new version to NPM and deploy API docs for that version to https://players.castlabs.com/react-dom/x.x.x/docs/. It gets triggered when we create a new Release in GitHub (when creating the release, select "Create new tag" and specify the target version).

Beta versions are also supported and they will be published accordingly to a NPM beta channel (non-main channel).