### PR TITLE
DE-6806: Use ESM entrypoint only

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,8 @@
     "url": "https://github.com/castlabs/prestoplay-react-components/issues"
   },
   "author": "castLabs GmbH (https://castlabs.com/)",
-  "browser": "dist/prestoplay-react.cjs.min.js",
-  "main": "dist/prestoplay-react.cjs.min.js",
-  "module": "dist/index.js",
-  "types": "dist/prestoplay-react.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "bash ./scripts/build.sh",
     "start": "bash ./scripts/start.sh",


### PR DESCRIPTION
Here I'm making sure we ship the ESM version of this library. It fixes a crash in 0.7.0.

(The CJS version is still shipped as well, but it won't be automatically picked up by Webpack or any other bundler)

### The long story

Currently we have a couple of entrypoints (browser, module, main) and which entrypoint is used that depends solely on the bundler.

With the current package.json we have a serious problem for Webpack, because it will by default select our "browser" entrypoint (CJS) and for our dependency `@react-hook/resize-observer` it will select the "module" entrypoint (ESM).

This mixing of CJS with ESM typically does not work correctly, at least not when using default imports/exports. This is the case for both Webpack and Rollup, it doesn't work correctly there.

In our case, that's exactly what is happening, we have a default import from the `@react-hook/resize-observer` library:

```
import useResizeObserver from '@react-hook/resize-observer'
```

To avoid running into this problem, change the entrypoint to always point to the ESM build.

This should be a safe solution assuming our dependencies also correctly provide an ESM variant and assuming that the bundler supports ESM, which I think is a safe assumption.