### PR TITLE
Do not detach presto listeners

### DIFF
--- a/app/src/BasicOverlayPage.tsx
+++ b/app/src/BasicOverlayPage.tsx
@@ -5,7 +5,7 @@ import '@castlabs/prestoplay/cl.hls'
 import '@castlabs/prestoplay/cl.htmlcue'
 import '@castlabs/prestoplay/cl.ttml'
 import '@castlabs/prestoplay/cl.vtt'
-import React, { useState } from 'react'
+import React, { useMemo } from 'react'
 
 import { DefaultTrackLabelerOptions, Player, BaseThemeOverlay, PlayerSurface } from '../../src'
 
@@ -19,20 +19,18 @@ export const BasicOverlayPage = (props: {
   asset?: Asset
   autoload?: boolean
 }) => {
-  const [showStartButton, setShowStartButton] = useState<boolean>(true)
-  const [showPoster, setShowPoster] = useState<boolean>(true)
-
-  // Create the player as state of this component
-  const [player] = useState(new Player(pp => {
-    pp.use(clpp.dash.DashComponent)
-    pp.use(clpp.hls.HlsComponent)
-    pp.use(clpp.htmlcue.HtmlCueComponent)
-    pp.use(clpp.ttml.TtmlComponent)
-    pp.use(clpp.vtt.VttComponent)
-  }))
-
   const asset = props.asset
   const playerConfig = asset?.config
+
+  const player = useMemo(() => {
+    return new Player(pp => {
+      pp.use(clpp.dash.DashComponent)
+      pp.use(clpp.hls.HlsComponent)
+      pp.use(clpp.htmlcue.HtmlCueComponent)
+      pp.use(clpp.ttml.TtmlComponent)
+      pp.use(clpp.vtt.VttComponent)
+    })
+  }, [])
 
   // set options for the default track labeler
   player.trackLabelerOptions = {
@@ -44,37 +42,15 @@ export const BasicOverlayPage = (props: {
   } as DefaultTrackLabelerOptions
 
   return (
-    <>
-      <PlayerSurface
-        player={player}
-        config={playerConfig}
-        autoload={props.autoload}
-        playsInline={true}
-      >
-        <BaseThemeOverlay
-          startButton={!props.autoload && showStartButton}
-          posterUrl={showPoster ? asset?.poster: ''}
-          seekForward={10}
-          seekBackward={-10}
-          menuSelectionOptions={[
-            { type: 'audio', label: 'Language', hideCurrentlyActive:false, hideWhenUnavailable: true },
-            { type: 'text', label: 'Subtitles', hideCurrentlyActive:false, hideWhenUnavailable: true },
-            { type: 'video', label: 'Video', hideCurrentlyActive:false, hideWhenUnavailable: true },
-          ]}
-        />
-      </PlayerSurface>
-
-      <div className={'options'}>
-        <label>
-          <input type={'checkbox'} checked={showStartButton} onChange={() => {setShowStartButton(!showStartButton)}}/>
-          Show Start Button
-        </label>
-        <label>
-          <input type={'checkbox'} checked={showPoster} onChange={() => {setShowPoster(!showPoster)}}/>
-          Show Poster
-        </label>
-
-      </div>
-    </>
+    <PlayerSurface
+      player={player}
+      baseConfig={{}}
+      config={playerConfig}
+      autoload={true}
+      playsInline={true}
+      style={{ resize: 'both', overflow: 'auto', width: 900, height: 340 }}
+    >
+      <BaseThemeOverlay/>
+    </PlayerSurface>
   )
 }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -707,7 +707,6 @@ export class Player {
   }
 
   private async reset_() {
-    this.removePrestoListeners_()
     if (this.pp_) {
       await this.pp_.release()
     }


### PR DESCRIPTION
Detaching listeners in `reset_()` is
incorrect because that method is called
during load.

Hot fix: do not remove listeners since it
is unclear in which method it should be done
and we haven't been doing it until today anyway
so this is kind of a rollback.