### PR TITLE
DE-7266: Remove `patchIgnoreStateEnded`

### DIFF
--- a/app/src/InterstitialPage.tsx
+++ b/app/src/InterstitialPage.tsx
@@ -30,11 +30,6 @@ export const InterstitialPage = () => {
                   type: clpp.Type.HLS,
                 },
               }}
-              // Possibly it's something wrong with the AIP stream http://localhost:3000/vod-preroll.m3u8
-              // but unfortunately what happens is that we get state "Ended" and then the video
-              // continues playing for another cca 800ms. This would obviously cause a glitch
-              // in the UI so configure the player to ignore all ended states changes
-              patchIgnoreStateEnded={true}
               hasTopControlsBar={false}
               interstitialOptions={{
               // Start resolving X-ASSET-LIST 15 seconds or less before

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -313,10 +313,6 @@ export class Player {
    */
   private _lastPlaybackState: State = State.Unset
   /**
-   * If true state changes to "ended" state should be ignored
-   */
-  private _ignoreStateEnded = false
-  /**
    * Timeline cues
    */
   private _cues: Cue[] = []
@@ -417,7 +413,7 @@ export class Player {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       const previousState = toState(e.detail.previousState)
 
-      if (this._ignoreStateEnded && currentState === State.Ended) {
+      if (currentState === State.Ended) {
         return
       }
 
@@ -542,18 +538,6 @@ export class Player {
 
   get trackManager() {
     return this.pp_?.getTrackManager() ?? null
-  }
-
-  /**
-   * Configure the player to ignore the "ended" state change. This is useful
-   * for situations where RESTOplay goes to the "ended" state prematurely, which
-   * sometimes happens (e.g. state changes to ended, but the video still plays
-   * another 800 ms or so and timeupdates are triggered).
-   * Not sure if this is a bug in PRESTOplay or a problem with the asset, but
-   * it happens.
-   */
-  set ignoreStateEnded(value: boolean) {
-    this._ignoreStateEnded = value
   }
 
   /**

--- a/src/interstitial/InterstitialPlayer.tsx
+++ b/src/interstitial/InterstitialPlayer.tsx
@@ -99,10 +99,6 @@ export type InterstitialPlayerProps = {
    */
   style?: React.CSSProperties
   /**
-   * If true, the player will ignore all state changes to state "ended".
-   */
-  patchIgnoreStateEnded?: boolean
-  /**
    * Render a custom top companion component.
    */
   renderTopCompanion?: (isFullScreen: boolean) => (JSX.Element | null)
@@ -124,12 +120,6 @@ export type InterstitialPlayerProps = {
  */
 export const InterstitialPlayer = React.memo((props: InterstitialPlayerProps) => {
   const playerRef = useRef(new PlayerHlsi(props.onHlsiPlayerReady))
-
-  useEffect(() => {
-    if (props.patchIgnoreStateEnded) {
-      playerRef.current.ignoreStateEnded = true
-    }
-  }, [props.patchIgnoreStateEnded])
 
   const load = async () => {
     try {


### PR DESCRIPTION
Here I'm removing a workaround which is no longer needed (because we fixed https://castlabs.atlassian.net/browse/DE-7073).