### PR TITLE
DE-7860: Display all timeline cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Do not show controls until video is loaded.
 * Fix rendering of cues in live in `BaseThemeOverlay` v2.
+* Support for displaying all timeline cues (except pre and post) is now added.
+  The cues don't need to have `schemeIdUri` set to `com.apple.hls.interstitial` anymore.
 
 # 0.9.1 (Beta)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 * Do not show controls until video is loaded.
 * Fix rendering of cues in live in `BaseThemeOverlay` v2.
-* Support for displaying all timeline cues (except pre and post) is now added.
-  The cues don't need to have `schemeIdUri` set to `com.apple.hls.interstitial` anymore.
+* Display all timeline cues except preroll and postroll.
 
 # 0.9.1 (Beta)
 

--- a/src/components/seekbar/utils.ts
+++ b/src/components/seekbar/utils.ts
@@ -66,6 +66,7 @@ export async function seekToPercent(player: clpp.Player, percent: number) {
 function isPreOrPostCue (cue: clpp.TimelineCue): boolean {
   const cueAttribute = cue.customAttributes?.CUE
   if (!cueAttribute) {return false}
+  if (cue.schemeIdUri !== 'com.apple.hls.interstitial') {return false}
   if (cueAttribute.includes('PRE') || cueAttribute.includes('POST')) {
     return true
   }
@@ -75,7 +76,6 @@ function isPreOrPostCue (cue: clpp.TimelineCue): boolean {
 export function getUiCues (player: clpp.Player): Cue[] {
   const range = player.getSeekRange() as SeekRange
   return player.getTimelineCues()
-    .filter(cue => cue.schemeIdUri === 'com.apple.hls.interstitial')
     .filter(cue => !isPreOrPostCue(cue))
     .map(cue => {
       return {


### PR DESCRIPTION
Until now, we were showing only cues with `schemeIdUri` `com.apple.hls.interstitial`, but some cues do not have this attribute.
We remove the condition here to show all timeline cues.
The filter for pre and post cues is kept.