### PR TITLE
DE-7895: Hide buffering spinner during ads

### DIFF
--- a/src/components/BufferingIndicator.tsx
+++ b/src/components/BufferingIndicator.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useDebugValue, useState } from 'react'
 
 import { PrestoContext } from '../context/PrestoContext'
+import { useAd } from '../hooks/hooks'
 import { State } from '../Player'
 import { usePrestoUiEvent } from '../react'
 
@@ -24,6 +25,7 @@ const isBufferingState = (state: State): boolean => {
 const useIsBuffering = (): boolean => {
   const { player } = useContext(PrestoContext)
   const [buffering, setBuffering] = useState(isBufferingState(player?.state ?? State.Idle))
+  const ad = useAd()
 
   usePrestoUiEvent('statechanged', (event) => {
     setBuffering(isBufferingState(event.currentState))
@@ -31,7 +33,7 @@ const useIsBuffering = (): boolean => {
 
   useDebugValue(buffering ? 'buffering' : 'not buffering')
 
-  return buffering
+  return buffering && !ad
 }
 
 /**


### PR DESCRIPTION
Buffering spinner is based on buffering of primary content so hide it during ads when primary is in
the background, and ads typically load fast.